### PR TITLE
Merge changes from submit-postgame-thread-faster into current

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -251,8 +251,6 @@ class Bot:
                             try:
                                 sub.edit(str)
                                 print "Edits submitted..."
-                                print "Sleeping for two minutes..."
-                                print datetime.strftime(check, "%d %I:%M %p")
                                 break
                             except Exception, err:
                                 print "Couldn't submit edits, trying again..."
@@ -298,9 +296,12 @@ class Bot:
                                     print "Stickying submission..."
                                     sub.sticky()
                                     print "Submission stickied..."
+                            time.sleep(10)
                             break
-                        else: time.sleep(120)
-                        time.sleep(10)
+                        else: 
+                            print "Sleeping for one minute..."
+                            print datetime.strftime(check, "%d %I:%M %p")
+                            time.sleep(60)
             if datetime.today().day == today.day:
                 timechecker.endofdaycheck()
 


### PR DESCRIPTION
- Reduced sleep to 60 seconds
- Moved log lines down to where the sleep is actually happening, updated time in the log line from two minutes to one minute
- Moved 10 second sleep inside the `if pgt_submit:` block, since that is the case it is meant for